### PR TITLE
add directory slash to make prod path work

### DIFF
--- a/src/processHref.js
+++ b/src/processHref.js
@@ -1,6 +1,6 @@
 function processHref(href) {
   if (process.env.NODE_ENV === 'production') {
-    return process.env.STATIC_ROOT + '_all.css';
+    return process.env.STATIC_ROOT + '/_all.css';
   }
   return href;
 }


### PR DESCRIPTION
In case the slash isn't in `STATIC_ROOT`.
